### PR TITLE
1-change-npm-run-serve-to-npm-run-dev-for-convenience

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,7 +1,5 @@
 {
-    "watch": [
-        "src"
-    ],
-    "ext": "ts,js",
-    "exec": "node --env-file=.env dist/index.js"
+  "watch": ["src"],
+  "ext": "ts,js",
+  "exec": "cross-env NODE_ENV=development node --env-file=.env dist/index.js"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/express": "^4.17.21",
         "@types/morgan": "^1.9.9",
         "concurrently": "^8.2.2",
+        "cross-env": "^7.0.3",
         "nodemon": "^3.0.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
@@ -843,6 +844,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "rimraf dist && npx tsc",
     "prestart": "npm run build",
     "start": "cross-env NODE_ENV=production node --env-file=.env dist/index.js",
-    "preserve": "npm run build",
-    "serve": "concurrently \"npx tsc -w\" \"nodemon\""
+    "predev": "npm run build",
+    "dev": "concurrently \"npx tsc -w\" \"nodemon\""
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "rimraf dist && npx tsc",
     "prestart": "npm run build",
-    "start": "node --env-file=.env dist/index.js",
+    "start": "cross-env NODE_ENV=production node --env-file=.env dist/index.js",
     "preserve": "npm run build",
     "serve": "concurrently \"npx tsc -w\" \"nodemon\""
   },
@@ -30,6 +30,7 @@
     "@types/express": "^4.17.21",
     "@types/morgan": "^1.9.9",
     "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
     "nodemon": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"


### PR DESCRIPTION
turns out it is that simple:

```diff
- "preserve"
- "serve"
+ "predev"
+ "dev"
```